### PR TITLE
Convert colon to underscore

### DIFF
--- a/lib/tiddle/model_name.rb
+++ b/lib/tiddle/model_name.rb
@@ -1,11 +1,17 @@
 module Tiddle
   class ModelName
     def with_underscores(model)
-      model.model_name.to_s.underscore.upcase
+      colon_to_underscore(model).underscore.upcase
     end
 
     def with_dashes(model)
       with_underscores(model).dasherize
+    end
+
+    private
+
+    def colon_to_underscore(model)
+      model.model_name.to_s.gsub(':', '_')
     end
   end
 end

--- a/lib/tiddle/model_name.rb
+++ b/lib/tiddle/model_name.rb
@@ -11,7 +11,7 @@ module Tiddle
     private
 
     def colon_to_underscore(model)
-      model.model_name.to_s.gsub(':', '_')
+      model.model_name.to_s.tr(':', '_')
     end
   end
 end

--- a/spec/rails_app_active_record/app/controllers/namespaced_users_controller.rb
+++ b/spec/rails_app_active_record/app/controllers/namespaced_users_controller.rb
@@ -1,0 +1,7 @@
+class NamespacedUsersController < ApplicationController
+  before_action :authenticate_namespaced_user!
+
+  def index
+    head :ok
+  end
+end

--- a/spec/rails_app_active_record/app/models/namespace/namespaced_user.rb
+++ b/spec/rails_app_active_record/app/models/namespace/namespaced_user.rb
@@ -1,0 +1,9 @@
+module Namespace
+  class NamespacedUser < ActiveRecord::Base
+    devise :database_authenticatable, :registerable,
+           :recoverable, :trackable, :validatable,
+           :token_authenticatable
+
+    has_many :authentication_tokens, as: :authenticatable
+  end
+end

--- a/spec/rails_app_active_record/config/routes.rb
+++ b/spec/rails_app_active_record/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   devise_for :admin_users
+  devise_for :namespaced_user, class_name: 'Namespace::NamespacedUser'
   resources :secrets, only: [:index], defaults: { format: 'json' }
   resources :long_secrets, only: [:index], defaults: { format: 'json' }
+  resources :namespaced_users, only: [:index], defaults: { format: 'json' }
 end

--- a/spec/rails_app_active_record/db/migrate/20150217000000_create_tables.rb
+++ b/spec/rails_app_active_record/db/migrate/20150217000000_create_tables.rb
@@ -59,6 +59,27 @@ class CreateTables < ActiveRecord::Migration[4.2]
 
       t.timestamps null: false
     end
+
+    create_table(:namespaced_users) do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+
+      t.string :nick_name
+
+      t.timestamps null: false
+    end
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength

--- a/spec/rails_app_mongoid/app/controllers/namespaced_users_controller.rb
+++ b/spec/rails_app_mongoid/app/controllers/namespaced_users_controller.rb
@@ -1,0 +1,7 @@
+class NamespacedUsersController < ApplicationController
+  before_action :authenticate_namespaced_user!
+
+  def index
+    head :ok
+  end
+end

--- a/spec/rails_app_mongoid/app/models/namespace/namespaced_user.rb
+++ b/spec/rails_app_mongoid/app/models/namespace/namespaced_user.rb
@@ -1,0 +1,4 @@
+module Namespace
+  class NamespacedUser < User
+  end
+end

--- a/spec/rails_app_mongoid/config/routes.rb
+++ b/spec/rails_app_mongoid/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   devise_for :admin_users
+  devise_for :namespaced_user, class_name: 'Namespace::NamespacedUser'
   resources :secrets, only: [:index], defaults: { format: 'json' }
   resources :long_secrets, only: [:index], defaults: { format: 'json' }
+  resources :namespaced_users, only: [:index], defaults: { format: 'json' }
 end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -130,6 +130,27 @@ describe "Authentication using Tiddle strategy", type: :request do
     end
   end
 
+  context "when the model name is composed of a namespace" do
+    before do
+      @user = Namespace::NamespacedUser.create!(
+        email: "test@example.com",
+        password: "12345678"
+      )
+      @token = Tiddle.create_and_return_token(@user, FakeRequest.new)
+    end
+
+    it "allows to access endpoints which require authentication" do
+      get(
+        namespaced_users_path,
+        headers: {
+          "X-NAMESPACE--NAMESPACED-USER-EMAIL" => "test@example.com",
+          "X-NAMESPACE--NAMESPACED-USER-TOKEN" => @token
+        }
+      )
+      expect(response.status).to eq 200
+    end
+  end
+
   describe "using field other than email" do
     before do
       Devise.setup do |config|


### PR DESCRIPTION
As described in [RFC-7230](https://www.rfc-editor.org/rfc/rfc7230#page-27), the HTTP header doesn't accept `/` and many other special characters.

So, the `Module::Class` information from an ActiveRecord instance will have the `::` changed to a `/`, which causes an error.

This PR replaces every `:`to a `_`. This way, we'll have `Module__Class`, allowing the HTTP header to be built following `MODULE--CLASS` format.