### PR TITLE
Rename deprecated Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 15
 
-Gemspec/DateAssignment:
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 Layout/SpaceBeforeBrackets:
   Enabled: true


### PR DESCRIPTION
It renames a deprecated Rubocop rule that is not supported anymore:

```
Error: The `Gemspec/DateAssignment` cop has been removed. Please use `Gemspec/DeprecatedAttributeAssignment` instead.
(obsolete configuration found in .rubocop.yml, please update it)
```