### PR TITLE
fix(security): sync with upstream 1.8.1 + relax devise constraint for 5.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,24 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - rails5.2
-          - rails6.0
           - rails6.1
           - rails7.0
         ruby:
-          - "2.7"
           - "3.0"
           - "3.1"
         backend:
           - active_record
           - mongoid
         exclude:
-          - gemfile: rails5.2
-            ruby: "3.0"
-          - gemfile: rails5.2
-            ruby: "3.1"
-          - gemfile: rails6.0
-            ruby: "3.1"
           - gemfile: rails6.1
             ruby: "3.1"
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}, ${{ matrix.backend }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,7 @@ jobs:
         gemfile:
           - rails6.1
           - rails7.0
+          - rails7.1
         ruby:
           - "3.0"
           - "3.1"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,12 +18,11 @@ jobs:
         ruby:
           - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
         backend:
           - active_record
           - mongoid
-        exclude:
-          - gemfile: rails6.1
-            ruby: "3.1"
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}, ${{ matrix.backend }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - rails6.1
           - rails7.0
           - rails7.1
         ruby:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'spec/spec_helper.rb'
     - 'vendor/bundle/**/*'
   SuggestExtensions: false
+  NewCops: enable
 Style/StringLiterals:
   Enabled: false
 Style/Documentation:
@@ -25,64 +26,3 @@ Metrics/BlockLength:
     - 'spec/**/*'
 Metrics/MethodLength:
   Max: 15
-
-Gemspec/DeprecatedAttributeAssignment:
-  Enabled: true
-Layout/SpaceBeforeBrackets:
-  Enabled: true
-Lint/AmbiguousAssignment:
-  Enabled: true
-Lint/DeprecatedConstants:
-  Enabled: true
-Lint/DuplicateBranch:
-  Enabled: true
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: true
-Lint/EmptyBlock:
-  Enabled: true
-Lint/EmptyClass:
-  Enabled: true
-Lint/LambdaWithoutLiteralBlock:
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
-Lint/NumberedParameterAssignment:
-  Enabled: true
-Lint/OrAssignmentToConstant:
-  Enabled: true
-Lint/RedundantDirGlobSort:
-  Enabled: true
-Lint/SymbolConversion:
-  Enabled: true
-Lint/ToEnumArguments:
-  Enabled: true
-Lint/TripleQuotes:
-  Enabled: true
-Lint/UnexpectedBlockArity:
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-Style/ArgumentsForwarding:
-  Enabled: true
-Style/CollectionCompact:
-  Enabled: true
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-Style/EndlessMethod:
-  Enabled: true
-Style/HashConversion:
-  Enabled: true
-Style/HashExcept:
-  Enabled: true
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-Style/NegatedIfElseCondition:
-  Enabled: true
-Style/NilLambda:
-  Enabled: true
-Style/RedundantArgument:
-  Enabled: true
-Style/StringChars:
-  Enabled: true
-Style/SwapValues:
-  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 1.8.1
+
+Remove Rails 5.2 and 6.0 support
+
+Remove Ruby 2.7 support
+
+Add Rails 7.1 support
+
+Add Ruby 3.2 and 3.3 support
+
 ### 1.8.0
 
 Support different touch interval based on expiration time (Daniel André da Silva)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1-alpine
+FROM ruby:3.3-alpine
 
 RUN apk add build-base sqlite-dev tzdata git bash
 RUN gem update --system && gem install bundler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   library:
+    platform: linux/x86_64
     build:
       context: .
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - redis
     environment:
       - REDIS_URL=redis://redis:6379/1
-      - BUNDLE_GEMFILE=gemfiles/rails7.0.gemfile
+      - BUNDLE_GEMFILE=gemfiles/rails7.1.gemfile
   redis:
     image: "redis:6-alpine"
     command: redis-server

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 5.2.1"
-gem "mongoid", "~> 6"
-gem "sqlite3", "~> 1.3.13"
-
-gemspec path: "../"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 6.0.0"
-gem "mongoid", "~> 7"
-gem "sqlite3"
-
-gemspec path: "../"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
 gem "mongoid"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 6.1.0"
-gem "mongoid"
-gem "sqlite3", "~> 1.4"
-
-gemspec path: "../"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0.2"
 gem "mongoid"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.1.3"
+gem "mongoid"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"

--- a/lib/tiddle/version.rb
+++ b/lib/tiddle/version.rb
@@ -1,3 +1,3 @@
 module Tiddle
-  VERSION = "1.8.0".freeze
+  VERSION = "1.8.1".freeze
 end

--- a/spec/support/backend.rb
+++ b/spec/support/backend.rb
@@ -23,14 +23,10 @@ module Backend
       # Do initial migration
       path = File.expand_path("../rails_app_active_record/db/migrate/", File.dirname(__FILE__))
 
-      if Gem::Requirement.new(">= 6.0.0") =~ Rails.gem_version
-        ActiveRecord::MigrationContext.new(
-          path,
-          ActiveRecord::SchemaMigration
-        ).migrate
-      else
-        ActiveRecord::MigrationContext.new(path).migrate
-      end
+      ActiveRecord::MigrationContext.new(
+        path,
+        ActiveRecord::SchemaMigration
+      ).migrate
     end
   end
 

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_dependency "devise", ">= 4.0.0.rc1", "< 5"
-  spec.add_dependency "activerecord", ">= 5.2.0"
+  spec.add_dependency "activerecord", ">= 6.1.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "simplecov"

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 5"
+  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 6"
   spec.add_dependency "activerecord", ">= 6.1.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
## Summary

- Syncs fork with upstream tiddle 1.8.1 (from 1.8.0)
- Relaxes devise dependency from `< 5` to `< 6` to unblock devise 5.0.3 upgrade

This allows consumers (rails-identity-service, works) to upgrade to devise 5.0.3 which fixes **CVE-2026-32700** (confirmable "change email" race condition).

Tiddle only uses stable Devise APIs (`Devise.add_module`, `Devise::Strategies::Authenticatable`, `Devise.token_generator`) — no breaking changes expected.

## Test plan

- [ ] Tiddle's existing test suite passes with devise 5.0.3
- [ ] rails-identity-service specs pass after upgrading tiddle + devise
- [ ] works specs pass after upgrading tiddle + devise

🤖 Generated with [Claude Code](https://claude.com/claude-code)